### PR TITLE
Add canvas smiley face with toggleable features

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,20 @@
-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Canvas Smiley Toggle</title>
+  <style>
+    canvas { border: 1px solid #ccc; }
+    button { margin: 5px; }
+  </style>
+</head>
+<body>
+  <canvas id="face" width="300" height="300"></canvas>
+  <div>
+    <button id="toggleEyes">Toggle Eyes</button>
+    <button id="toggleNose">Toggle Nose</button>
+    <button id="toggleMouth">Toggle Mouth</button>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,1 +1,63 @@
+const canvas = document.getElementById('face');
+const ctx = canvas.getContext('2d');
 
+let eyes = true;
+let nose = true;
+let mouth = true;
+
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  // head
+  ctx.fillStyle = '#ffeb3b';
+  ctx.beginPath();
+  ctx.arc(150, 150, 100, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.stroke();
+
+  if (eyes) {
+    ctx.fillStyle = '#000';
+    ctx.beginPath();
+    ctx.arc(110, 120, 10, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.beginPath();
+    ctx.arc(190, 120, 10, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  if (nose) {
+    ctx.fillStyle = '#ffa500';
+    ctx.beginPath();
+    ctx.moveTo(150, 140);
+    ctx.lineTo(140, 170);
+    ctx.lineTo(160, 170);
+    ctx.closePath();
+    ctx.fill();
+  }
+
+  if (mouth) {
+    ctx.strokeStyle = '#000';
+    ctx.lineWidth = 5;
+    ctx.beginPath();
+    ctx.arc(150, 170, 50, 0, Math.PI, false);
+    ctx.stroke();
+  }
+}
+
+document.getElementById('toggleEyes').addEventListener('click', () => {
+  eyes = !eyes;
+  draw();
+});
+
+document.getElementById('toggleNose').addEventListener('click', () => {
+  nose = !nose;
+  draw();
+});
+
+document.getElementById('toggleMouth').addEventListener('click', () => {
+  mouth = !mouth;
+  draw();
+});
+
+draw();


### PR DESCRIPTION
## Summary
- Draw a smiley face on an HTML5 canvas
- Add buttons to toggle eyes, nose, and mouth on the canvas

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a9ed12134832f8cf8e42b981b4c4f